### PR TITLE
snowflake_legacy 0.10.0 :snowflake:

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake_legacy" %}
-{% set version = "0.8.0" %}
+{% set version = "0.10.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,8 +7,9 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 37096bb0020a52d641683ac8a705122dcae4b79b45ad3289d115dd82ba102af5
+  sha256: 94ebe66f9a45ac7c41f989c999fd36bf9dfaad15089565981e42aca6faef4b85
   patches:
+    # update 0.10.0: patch still needed
     - patches/0001-fix-pyproject-paths.patch
 
 build:


### PR DESCRIPTION
snowflake_legacy 0.10.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5154]
- dev_url (private): https://pypi.org/project/snowflake._legacy
- conda-forge: _feedstock not found on conda-forge_
- pypi: https://pypi.org/project/snowflake_legacy/0.10.0
- pypi inspector: https://inspector.pypi.io/project/snowflake_legacy/0.10.0

### Explanation of changes:

- bump version
- SF channel already in `abs.yaml` in `main`.


[PKG-5154]: https://anaconda.atlassian.net/browse/PKG-5154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ