### PR TITLE
snowflake_legacy 0.13.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "snowflake_legacy" %}
-{% set version = "0.13.0" %}
+{% set version = "0.13.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,9 +7,9 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 79b5fc5206490222f733b4c50828c26ce4ec382f82a30d622b8e9cbbac1048e7
+  sha256: 295db58007ec92c19b739cfb1749504b231b51d0f93e62affb5cb6a1d23710d5
   patches:
-    # update 0.13.0: patch still needed
+    # update 0.13.1: patch still needed
     - patches/0001-fix-pyproject-paths.patch
 
 build:


### PR DESCRIPTION
snowflake_legacy 0.13.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5920](https://anaconda.atlassian.net/browse/PKG-5920)
- [Upstream repository](https://pypi.org/project/snowflake._legacy)

### Explanation of changes:

- Updated to 0.13.1, no dependency changes, patch is still required.


[PKG-5920]: https://anaconda.atlassian.net/browse/PKG-5920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ